### PR TITLE
fix: adds number to branch name regex (CT-000)

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 
 const branchName = require('current-git-branch');
 
-const branchRegex = /^\w+\/(\S+\/)?[A-Za-z]+-\d+$/;
+const branchRegex = /^\w+\/(\S+\/)?[A-Z][\dA-Z]{1,2}-\d+$/;
 const EXCEPTIONS = [/^production$/, /^trying$/, /^staging$/, /^master$/, /^break-glass.*$/];
 
 try {


### PR DESCRIPTION
**Fixes or implements CT-000**

### Brief description. What is this change?
- `CT-000` ✅ 
- `VF-000` ✅ 
- `NLU-000` ✅ 
 - `NL3-000` ✅ 
 - `N33-000` ✅ 
 -  `3NL-000` ⚠️  (require letter as first character on left side)
- `nlu-000` ⚠️  (require uppercase letters)
- `NLUU-000` ⚠️  (require 3 characters on left side)